### PR TITLE
feat: visual layout presets and project open performance fix

### DIFF
--- a/src/components/editor/CenterPanel.tsx
+++ b/src/components/editor/CenterPanel.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useRef, useState } from "react";
 import { useEditorStore } from "@/stores/editorStore";
-import { usePreviewStore, type ViewMode } from "@/stores/previewStore";
+import { usePreviewStore } from "@/stores/previewStore";
+import { LayoutPresetPicker } from "./LayoutPresetPicker";
 import { EditorCanvas } from "./EditorCanvas";
 import { BiomeRangeEditor } from "./BiomeRangeEditor";
 import { BiomeSectionTabs } from "./BiomeSectionTabs";
@@ -10,52 +11,6 @@ import { InstanceEditorView } from "./InstanceEditorView";
 import { PreviewPanel } from "../preview/PreviewPanel";
 import { ComparisonView } from "../preview/ComparisonView";
 import { DiagnosticsStrip } from "../preview/DiagnosticsStrip";
-
-const VIEW_MODES: { key: ViewMode; label: string }[] = [
-  { key: "graph", label: "Graph" },
-  { key: "preview", label: "Preview" },
-  { key: "split", label: "Split" },
-  { key: "compare", label: "Compare" },
-  { key: "json", label: "{ }" },
-];
-
-/** Floating pill overlay for view-mode switching — sits in top-right of canvas area */
-const ViewModeOverlay = memo(function ViewModeOverlay() {
-  const viewMode = usePreviewStore((s) => s.viewMode);
-  const setViewMode = usePreviewStore((s) => s.setViewMode);
-  const splitDirection = usePreviewStore((s) => s.splitDirection);
-  const setSplitDirection = usePreviewStore((s) => s.setSplitDirection);
-
-  return (
-    <div className="absolute top-2 right-2 z-20 flex items-center gap-0.5 bg-tn-surface/80 backdrop-blur-sm border border-tn-border/60 rounded-lg shadow-lg px-1 py-0.5">
-      {VIEW_MODES.map(({ key, label }) => {
-        const isActive = key === viewMode;
-        return (
-          <button
-            key={key}
-            onClick={() => setViewMode(key)}
-            className={`px-2 py-0.5 text-[11px] font-medium rounded transition-colors ${
-              isActive
-                ? "bg-tn-accent/20 text-tn-accent"
-                : "text-tn-text-muted hover:text-tn-text hover:bg-white/5"
-            }`}
-          >
-            {label}
-          </button>
-        );
-      })}
-      {viewMode === "split" && (
-        <button
-          onClick={() => setSplitDirection(splitDirection === "horizontal" ? "vertical" : "horizontal")}
-          className="px-1.5 py-0.5 text-[11px] font-medium rounded transition-colors text-tn-text-muted hover:text-tn-text hover:bg-white/5 ml-0.5 border-l border-tn-border/40 pl-1.5"
-          title={`Split: ${splitDirection === "horizontal" ? "Horizontal" : "Vertical"} (V)`}
-        >
-          {splitDirection === "horizontal" ? "H" : "V"}
-        </button>
-      )}
-    </div>
-  );
-});
 
 const SplitView = memo(function SplitView() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -131,7 +86,7 @@ const DensityView = memo(function DensityView() {
     <div className="flex flex-col h-full">
       <DiagnosticsStrip />
       <div className="flex-1 min-h-0 relative">
-        <ViewModeOverlay />
+        <LayoutPresetPicker />
         {viewMode === "graph" && <EditorCanvas />}
         {viewMode === "preview" && <PreviewPanel />}
         {viewMode === "split" && <SplitView />}
@@ -218,12 +173,12 @@ const NoiseRangeView = memo(function NoiseRangeView() {
 
       {viewMode === "preview" ? (
         <div className="flex-1 min-h-0 relative">
-          <ViewModeOverlay />
+          <LayoutPresetPicker />
           <PreviewPanel />
         </div>
       ) : viewMode === "split" ? (
         <div ref={containerRef} className="flex-1 min-h-0 flex flex-col relative">
-          <ViewModeOverlay />
+          <LayoutPresetPicker />
           <div className="shrink-0" style={{ height: editorHeight }}>
             <BiomeRangeEditor />
           </div>
@@ -237,17 +192,17 @@ const NoiseRangeView = memo(function NoiseRangeView() {
         </div>
       ) : viewMode === "compare" ? (
         <div className="flex-1 min-h-0 relative">
-          <ViewModeOverlay />
+          <LayoutPresetPicker />
           <ComparisonView />
         </div>
       ) : viewMode === "json" ? (
         <div className="flex-1 min-h-0 relative">
-          <ViewModeOverlay />
+          <LayoutPresetPicker />
           <JsonEditorView content={originalWrapper} onChange={setJsonViewDraft} />
         </div>
       ) : (
         <div ref={containerRef} className="flex-1 min-h-0 flex flex-col relative">
-          <ViewModeOverlay />
+          <LayoutPresetPicker />
           <div className="shrink-0" style={{ height: editorHeight }}>
             <BiomeRangeEditor />
           </div>
@@ -277,7 +232,7 @@ const BiomeView = memo(function BiomeView() {
       </div>
       <DiagnosticsStrip />
       <div className="flex-1 min-h-0 relative">
-        <ViewModeOverlay />
+        <LayoutPresetPicker />
         {viewMode === "graph" && <EditorCanvas />}
         {viewMode === "preview" && <PreviewPanel />}
         {viewMode === "split" && <SplitView />}

--- a/src/components/editor/LayoutPresetPicker.tsx
+++ b/src/components/editor/LayoutPresetPicker.tsx
@@ -1,0 +1,145 @@
+import { memo } from "react";
+import { usePreviewStore } from "@/stores/previewStore";
+import type { ViewMode, SplitDirection } from "@/stores/previewStore";
+
+interface Preset {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  activate: (
+    setViewMode: (vm: ViewMode) => void,
+    setSplitDirection: (dir: SplitDirection) => void,
+  ) => void;
+  isActive: (vm: ViewMode, dir: SplitDirection) => boolean;
+}
+
+const PRESETS: Preset[] = [
+  {
+    id: "graph",
+    label: "Graph",
+    icon: (
+      <svg viewBox="0 0 24 18" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
+        {/* Full pane with node dots + edges */}
+        <rect x="2" y="1" width="20" height="16" rx="2" />
+        <circle cx="7" cy="6" r="1.5" fill="currentColor" stroke="none" />
+        <circle cx="17" cy="6" r="1.5" fill="currentColor" stroke="none" />
+        <circle cx="12" cy="13" r="1.5" fill="currentColor" stroke="none" />
+        <line x1="8.3" y1="6.6" x2="11" y2="12" />
+        <line x1="15.7" y1="6.6" x2="13" y2="12" />
+      </svg>
+    ),
+    activate: (setViewMode) => setViewMode("graph"),
+    isActive: (vm) => vm === "graph",
+  },
+  {
+    id: "preview",
+    label: "Preview",
+    icon: (
+      <svg viewBox="0 0 24 18" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
+        {/* Full pane with gradient/contour lines */}
+        <rect x="2" y="1" width="20" height="16" rx="2" />
+        <path d="M2 6 C6 4, 10 8, 14 5 C18 2, 20 7, 22 6" />
+        <path d="M2 10 C6 8, 10 12, 14 9 C18 6, 20 11, 22 10" />
+        <path d="M2 14 C6 12, 10 16, 14 13 C18 10, 20 15, 22 14" />
+      </svg>
+    ),
+    activate: (setViewMode) => setViewMode("preview"),
+    isActive: (vm) => vm === "preview",
+  },
+  {
+    id: "split-h",
+    label: "Split Horizontal",
+    icon: (
+      <svg viewBox="0 0 24 18" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
+        {/* Top=graph, bottom=preview, horizontal divider */}
+        <rect x="2" y="1" width="20" height="16" rx="2" />
+        <line x1="2" y1="9" x2="22" y2="9" />
+        <circle cx="8" cy="5" r="1" fill="currentColor" stroke="none" />
+        <circle cx="16" cy="5" r="1" fill="currentColor" stroke="none" />
+        <line x1="9" y1="5.3" x2="15" y2="5.3" />
+        <line x1="4" y1="13" x2="20" y2="13" strokeDasharray="2 2" />
+      </svg>
+    ),
+    activate: (setViewMode, setSplitDirection) => {
+      setViewMode("split");
+      setSplitDirection("horizontal");
+    },
+    isActive: (vm, dir) => vm === "split" && dir === "horizontal",
+  },
+  {
+    id: "split-v",
+    label: "Split Vertical",
+    icon: (
+      <svg viewBox="0 0 24 18" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
+        {/* Left=graph, right=preview, vertical divider */}
+        <rect x="2" y="1" width="20" height="16" rx="2" />
+        <line x1="12" y1="1" x2="12" y2="17" />
+        <circle cx="7" cy="6" r="1" fill="currentColor" stroke="none" />
+        <circle cx="7" cy="12" r="1" fill="currentColor" stroke="none" />
+        <line x1="7" y1="7" x2="7" y2="11" />
+        <line x1="14" y1="9" x2="20" y2="9" strokeDasharray="2 2" />
+      </svg>
+    ),
+    activate: (setViewMode, setSplitDirection) => {
+      setViewMode("split");
+      setSplitDirection("vertical");
+    },
+    isActive: (vm, dir) => vm === "split" && dir === "vertical",
+  },
+  {
+    id: "compare",
+    label: "Compare",
+    icon: (
+      <svg viewBox="0 0 24 18" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
+        {/* Two panels with A/B labels */}
+        <rect x="2" y="1" width="20" height="16" rx="2" />
+        <line x1="12" y1="1" x2="12" y2="17" />
+        <text x="7" y="11" textAnchor="middle" fill="currentColor" stroke="none" fontSize="7" fontWeight="bold">A</text>
+        <text x="17" y="11" textAnchor="middle" fill="currentColor" stroke="none" fontSize="7" fontWeight="bold">B</text>
+      </svg>
+    ),
+    activate: (setViewMode) => setViewMode("compare"),
+    isActive: (vm) => vm === "compare",
+  },
+  {
+    id: "json",
+    label: "JSON",
+    icon: (
+      <svg viewBox="0 0 24 18" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
+        {/* Curly brace glyph */}
+        <text x="12" y="13" textAnchor="middle" fill="currentColor" stroke="none" fontSize="12" fontWeight="bold">{"{ }"}</text>
+      </svg>
+    ),
+    activate: (setViewMode) => setViewMode("json"),
+    isActive: (vm) => vm === "json",
+  },
+];
+
+export const LayoutPresetPicker = memo(function LayoutPresetPicker() {
+  const viewMode = usePreviewStore((s) => s.viewMode);
+  const setViewMode = usePreviewStore((s) => s.setViewMode);
+  const splitDirection = usePreviewStore((s) => s.splitDirection);
+  const setSplitDirection = usePreviewStore((s) => s.setSplitDirection);
+
+  return (
+    <div className="absolute top-2 right-2 z-20 flex items-center gap-0.5 bg-tn-surface/80 backdrop-blur-sm border border-tn-border/60 rounded-lg shadow-lg px-1 py-1">
+      {PRESETS.map((preset) => {
+        const active = preset.isActive(viewMode, splitDirection);
+        return (
+          <button
+            key={preset.id}
+            title={preset.label}
+            onClick={() => preset.activate(setViewMode, setSplitDirection)}
+            className={`w-9 h-[26px] flex items-center justify-center rounded transition-colors ${
+              active
+                ? "bg-tn-accent/20 text-tn-accent"
+                : "text-tn-text-muted hover:text-tn-text hover:bg-white/5"
+            }`}
+          >
+            <span className="w-6 h-[18px] block">{preset.icon}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+});

--- a/src/components/home/HomeScreen.tsx
+++ b/src/components/home/HomeScreen.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useTauriIO } from "@/hooks/useTauriIO";
 import { useProjectStore } from "@/stores/projectStore";
 import { useRecentProjectsStore } from "@/stores/recentProjectsStore";
-import { openAssetPack as ipcOpenAssetPack, listDirectory } from "@/utils/ipc";
+import { listDirectory } from "@/utils/ipc";
 import mapDirEntry from "@/utils/mapDirEntry";
 import { NewProjectDialog } from "@/components/dialogs/NewProjectDialog";
 import { HomeSidebar, type SidebarTab } from "./HomeSidebar";
@@ -19,7 +19,6 @@ export function HomeScreen() {
 
   async function handleOpenRecentProject(path: string) {
     try {
-      await ipcOpenAssetPack(path);
       useProjectStore.getState().setProjectPath(path);
       const entries = await listDirectory(path);
       useProjectStore.getState().setDirectoryTree(entries.map(mapDirEntry));

--- a/src/hooks/useTauriIO.ts
+++ b/src/hooks/useTauriIO.ts
@@ -3,7 +3,6 @@ import { open, save } from "@tauri-apps/plugin-dialog";
 import { useProjectStore } from "@/stores/projectStore";
 import { useEditorStore } from "@/stores/editorStore";
 import {
-  openAssetPack,
   saveAssetPack,
   readAssetFile,
   writeAssetFile,
@@ -199,7 +198,6 @@ export function useTauriIO() {
       if (!selected) return;
 
       const path = typeof selected === "string" ? selected : selected;
-      await openAssetPack(path);
       setProjectPath(path);
 
       const entries = await listDirectory(path);


### PR DESCRIPTION
## Summary
- Replace text-based view mode overlay with SVG icon layout preset picker (WorldMachine-style)
- Split horizontal and vertical are now distinct presets instead of a mode + toggle
- Remove unused `openAssetPack` IPC call that was parsing every JSON/BSON file on project open, causing slow load times

Closes #3

## Test plan
- [ ] Open a density/biome file and verify the new layout preset icons appear in the top-right
- [ ] Click each preset icon and verify the correct layout renders
- [ ] Verify horizontal and vertical split presets work correctly
- [ ] Open a project and verify it loads significantly faster
- [ ] Verify recent projects on the home screen also open faster