### PR TITLE
feat: select hierarchy shortcut with toggle

### DIFF
--- a/src/components/editor/NodeContextMenu.tsx
+++ b/src/components/editor/NodeContextMenu.tsx
@@ -2,6 +2,7 @@ import { ContextMenuOverlay, ContextMenuItem, ContextMenuSeparator } from "./Con
 import { useEditorStore } from "@/stores/editorStore";
 import { useToastStore } from "@/stores/toastStore";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { resolveKeybinding } from "@/config/keybindings";
 import type { Node, Edge } from "@xyflow/react";
 
 interface NodeContextMenuProps {
@@ -119,21 +120,37 @@ export function NodeContextMenu({ x, y, nodeId, onClose }: NodeContextMenuProps)
       <ContextMenuSeparator />
       <ContextMenuItem
         label="Select Upstream"
+        shortcut={resolveKeybinding("selectUpstream")}
         onClick={() => {
           const upstream = getUpstreamNodeIds(selectedIds, store.edges);
-          store.setNodes(
-            store.nodes.map((n) => ({ ...n, selected: upstream.has(n.id) })),
-          );
+          const currentSelected = new Set(store.nodes.filter((n) => n.selected).map((n) => n.id));
+          if (upstream.size === currentSelected.size && [...upstream].every((id) => currentSelected.has(id))) {
+            // Toggle off: keep only the most-downstream nodes (tips) in the selection
+            const tips = new Set([...currentSelected].filter((id) =>
+              !store.edges.some((e) => e.source === id && currentSelected.has(e.target)),
+            ));
+            store.setNodes(store.nodes.map((n) => ({ ...n, selected: tips.has(n.id) })));
+          } else {
+            store.setNodes(store.nodes.map((n) => ({ ...n, selected: upstream.has(n.id) })));
+          }
           onClose();
         }}
       />
       <ContextMenuItem
         label="Select Downstream"
+        shortcut={resolveKeybinding("selectDownstream")}
         onClick={() => {
           const downstream = getDownstreamNodeIds(selectedIds, store.edges);
-          store.setNodes(
-            store.nodes.map((n) => ({ ...n, selected: downstream.has(n.id) })),
-          );
+          const currentSelected = new Set(store.nodes.filter((n) => n.selected).map((n) => n.id));
+          if (downstream.size === currentSelected.size && [...downstream].every((id) => currentSelected.has(id))) {
+            // Toggle off: keep only the most-upstream nodes (roots) in the selection
+            const roots = new Set([...currentSelected].filter((id) =>
+              !store.edges.some((e) => e.target === id && currentSelected.has(e.source)),
+            ));
+            store.setNodes(store.nodes.map((n) => ({ ...n, selected: roots.has(n.id) })));
+          } else {
+            store.setNodes(store.nodes.map((n) => ({ ...n, selected: downstream.has(n.id) })));
+          }
           onClose();
         }}
       />

--- a/src/config/keybindings.ts
+++ b/src/config/keybindings.ts
@@ -18,6 +18,8 @@ export const KEYBINDINGS: KeybindingDef[] = [
   { id: "search",             defaultKey: "Ctrl+F",         label: "Search Nodes",               category: "Canvas" },
   { id: "selectAll",          defaultKey: "Ctrl+A",         label: "Select All",                 category: "Canvas" },
   { id: "toggleRoot",         defaultKey: "Ctrl+T",         label: "Toggle Root",                category: "Canvas" },
+  { id: "selectUpstream",     defaultKey: "Ctrl+PageUp",    label: "Select Upstream",            category: "Canvas" },
+  { id: "selectDownstream",   defaultKey: "Ctrl+PageDown",  label: "Select Downstream",          category: "Canvas" },
 
   // ── Edit ────────────────────────────────────────────────────
   { id: "undo",               defaultKey: "Ctrl+Z",         label: "Undo",                       category: "Edit" },

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -105,6 +105,68 @@ export function useKeyboardShortcuts({ onSearchOpen, onQuickAdd }: ShortcutCallb
         return;
       }
 
+      // Select Upstream — toggle: select all ancestors, or collapse back to tips
+      if (matchesKeybinding("selectUpstream", e)) {
+        e.preventDefault();
+        const store = useEditorStore.getState();
+        const currentSelected = new Set(store.nodes.filter((n) => n.selected).map((n) => n.id));
+        if (currentSelected.size === 0) return;
+        // BFS upstream
+        const upstream = new Set<string>();
+        const queue = [...currentSelected];
+        while (queue.length > 0) {
+          const current = queue.shift()!;
+          if (upstream.has(current)) continue;
+          upstream.add(current);
+          for (const edge of store.edges) {
+            if (edge.target === current && !upstream.has(edge.source)) {
+              queue.push(edge.source);
+            }
+          }
+        }
+        if (upstream.size === currentSelected.size && [...upstream].every((id) => currentSelected.has(id))) {
+          // Toggle off: keep only the most-downstream nodes (tips)
+          const tips = new Set([...currentSelected].filter((id) =>
+            !store.edges.some((edge) => edge.source === id && currentSelected.has(edge.target)),
+          ));
+          store.setNodes(store.nodes.map((n) => ({ ...n, selected: tips.has(n.id) })));
+        } else {
+          store.setNodes(store.nodes.map((n) => ({ ...n, selected: upstream.has(n.id) })));
+        }
+        return;
+      }
+
+      // Select Downstream — toggle: select all descendants, or collapse back to roots
+      if (matchesKeybinding("selectDownstream", e)) {
+        e.preventDefault();
+        const store = useEditorStore.getState();
+        const currentSelected = new Set(store.nodes.filter((n) => n.selected).map((n) => n.id));
+        if (currentSelected.size === 0) return;
+        // BFS downstream
+        const downstream = new Set<string>();
+        const queue = [...currentSelected];
+        while (queue.length > 0) {
+          const current = queue.shift()!;
+          if (downstream.has(current)) continue;
+          downstream.add(current);
+          for (const edge of store.edges) {
+            if (edge.source === current && !downstream.has(edge.target)) {
+              queue.push(edge.target);
+            }
+          }
+        }
+        if (downstream.size === currentSelected.size && [...downstream].every((id) => currentSelected.has(id))) {
+          // Toggle off: keep only the most-upstream nodes (roots)
+          const roots = new Set([...currentSelected].filter((id) =>
+            !store.edges.some((edge) => edge.target === id && currentSelected.has(edge.source)),
+          ));
+          store.setNodes(store.nodes.map((n) => ({ ...n, selected: roots.has(n.id) })));
+        } else {
+          store.setNodes(store.nodes.map((n) => ({ ...n, selected: downstream.has(n.id) })));
+        }
+        return;
+      }
+
       // Ctrl+T — wire selected node → Root node
       if (matchesKeybinding("toggleRoot", e)) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- Add Ctrl+PageUp / Ctrl+PageDown keyboard shortcuts for Select Upstream / Select Downstream
- Toggle behavior: pressing again collapses back to the original selection
- Shortcuts displayed in the right-click node context menu
- Keybindings are user-customizable via Settings → Keyboard Shortcuts

Closes #2

## Test plan
- [ ] Select a node, press Ctrl+PageUp — verify all upstream ancestors are selected
- [ ] Press Ctrl+PageUp again — verify selection collapses back to the original node
- [ ] Same for Ctrl+PageDown with downstream nodes
- [ ] Right-click a node — verify shortcuts are shown next to Select Upstream/Downstream
- [ ] Multi-select nodes first, then use shortcuts — verify it works from multiple starting nodes