### PR TITLE
Fix Wayland crash on NVIDIA systems

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Work around WebKitGTK protocol error on Wayland with NVIDIA proprietary
+    // drivers (GH-9). The DMA-BUF renderer triggers "Error 71 (Protocol error)
+    // dispatching to Wayland display" and an instant crash on affected systems.
+    #[cfg(target_os = "linux")]
+    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     terranova_lib::run()
 }


### PR DESCRIPTION
Closes #9

## Summary
- Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` on Linux before WebKitGTK initializes
- The DMA-BUF renderer in WebKitGTK triggers `Error 71 (Protocol error) dispatching to Wayland display` on systems with NVIDIA proprietary drivers, causing an instant crash
- Only applies on Linux; env var is only set if not already present, so users can override

## Test plan
- [ ] Verify app launches on Wayland + NVIDIA (Fedora 43 / KDE Plasma 6)
- [ ] Verify no regression on X11 Linux
- [ ] Verify no impact on Windows/macOS (cfg-gated to Linux only)