### PR TITLE
feat: add filesystem path scope validation for Tauri commands

### DIFF
--- a/src-tauri/src/commands/io.rs
+++ b/src-tauri/src/commands/io.rs
@@ -1,17 +1,41 @@
-// TODO(security): The filesystem commands in this module (read_asset_file,
-// write_asset_file, copy_file, etc.) accept arbitrary paths and bypass
-// Tauri's filesystem scoping. A future PR should add path scope validation
-// to restrict operations to the project directory and hytale-assets cache.
 use crate::io::asset_pack::{AssetPack, DirectoryEntry};
+use crate::io::path_scope;
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tauri::{Emitter, Manager};
 
+// ── Project scope management ────────────────────────────────────────────────
+
+/// Register a project directory as an allowed root for filesystem commands.
+/// Called by the frontend when a project is opened.
+#[tauri::command]
+pub fn register_project_root(path: String) -> Result<(), String> {
+    let target = PathBuf::from(&path);
+    if !target.is_dir() {
+        return Err(format!("Not a directory: {}", path));
+    }
+    path_scope::register_allowed_root(&target);
+    // Also register the hytale-assets cache if it exists
+    if let Ok(cache_root) = crate::io::hytale_assets::get_hytale_assets_root() {
+        path_scope::register_allowed_root(&cache_root);
+    }
+    Ok(())
+}
+
+/// Unregister a project directory when it is closed.
+#[tauri::command]
+pub fn unregister_project_root(path: String) {
+    path_scope::unregister_allowed_root(Path::new(&path));
+}
+
+// ── Asset pack commands ─────────────────────────────────────────────────────
+
 /// Open an asset pack directory and parse all JSON files.
 #[tauri::command]
 pub fn open_asset_pack(path: String) -> Result<AssetPack, String> {
+    path_scope::validate_path_str(&path)?;
     let pack_path = PathBuf::from(&path);
     if !pack_path.is_dir() {
         return Err(format!("Not a directory: {}", path));
@@ -22,19 +46,24 @@ pub fn open_asset_pack(path: String) -> Result<AssetPack, String> {
 /// Save an asset pack back to disk (atomic write via temp + rename).
 #[tauri::command]
 pub fn save_asset_pack(pack: AssetPack) -> Result<(), String> {
+    path_scope::validate_path_str(&pack.path)?;
     pack.save().map_err(|e| e.to_string())
 }
+
+// ── Single-file commands ────────────────────────────────────────────────────
 
 /// Read a single JSON asset file.
 #[tauri::command]
 pub fn read_asset_file(path: String) -> Result<Value, String> {
-    let content = fs::read_to_string(&path).map_err(|e| format!("Failed to read {}: {}", path, e))?;
-    serde_json::from_str(&content).map_err(|e| format!("Invalid JSON in {}: {}", path, e))
+    path_scope::validate_path_str(&path)?;
+    let content = fs::read_to_string(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+    serde_json::from_str(&content).map_err(|e| format!("Invalid JSON: {}", e))
 }
 
 /// Write a single JSON asset file with atomic write.
 #[tauri::command]
 pub fn write_asset_file(path: String, content: Value) -> Result<(), String> {
+    path_scope::validate_path_str(&path)?;
     let json = serde_json::to_string_pretty(&content)
         .map_err(|e| format!("Failed to serialize: {}", e))?;
 
@@ -43,7 +72,7 @@ pub fn write_asset_file(path: String, content: Value) -> Result<(), String> {
 
     fs::write(&temp_path, &json).map_err(|e| format!("Failed to write temp file: {}", e))?;
     if let Err(e) = fs::rename(&temp_path, file_path) {
-        let _ = fs::remove_file(&temp_path); // clean up leaked .tmp
+        let _ = fs::remove_file(&temp_path);
         return Err(format!("Failed to rename: {}", e));
     }
 
@@ -53,6 +82,7 @@ pub fn write_asset_file(path: String, content: Value) -> Result<(), String> {
 /// Write a JSON asset file to an arbitrary path, creating parent directories.
 #[tauri::command]
 pub fn export_asset_file(path: String, content: Value) -> Result<(), String> {
+    path_scope::validate_path_str(&path)?;
     let file_path = Path::new(&path);
     if let Some(parent) = file_path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {}", e))?;
@@ -71,6 +101,7 @@ pub fn export_asset_file(path: String, content: Value) -> Result<(), String> {
 /// Write a raw text file to an arbitrary path, creating parent directories.
 #[tauri::command]
 pub fn write_text_file(path: String, content: String) -> Result<(), String> {
+    path_scope::validate_path_str(&path)?;
     let file_path = Path::new(&path);
     if let Some(parent) = file_path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {}", e))?;
@@ -87,12 +118,15 @@ pub fn write_text_file(path: String, content: String) -> Result<(), String> {
 /// Create a directory (and all parent directories) at the given path.
 #[tauri::command]
 pub fn create_directory(path: String) -> Result<(), String> {
+    path_scope::validate_path_str(&path)?;
     fs::create_dir_all(&path).map_err(|e| format!("Failed to create directory: {}", e))
 }
 
 /// Copy a file from source to destination, creating parent directories.
 #[tauri::command]
 pub fn copy_file(source: String, destination: String) -> Result<(), String> {
+    path_scope::validate_path_str(&source)?;
+    path_scope::validate_path_str(&destination)?;
     let dest_path = Path::new(&destination);
     if let Some(parent) = dest_path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {}", e))?;
@@ -104,12 +138,23 @@ pub fn copy_file(source: String, destination: String) -> Result<(), String> {
 /// List directory contents for the asset tree sidebar.
 #[tauri::command]
 pub fn list_directory(path: String) -> Result<Vec<DirectoryEntry>, String> {
+    path_scope::validate_path_str(&path)?;
     let dir_path = PathBuf::from(&path);
     if !dir_path.is_dir() {
         return Err(format!("Not a directory: {}", path));
     }
     DirectoryEntry::scan(&dir_path).map_err(|e| e.to_string())
 }
+
+/// Return true if the given path exists on disk (file or directory).
+#[tauri::command]
+pub fn path_exists(path: String) -> bool {
+    // path_exists is read-only and low-risk, so we allow it without scope
+    // validation to support pre-project checks (e.g. settings dialog).
+    Path::new(&path).exists()
+}
+
+// ── Hytale asset commands ───────────────────────────────────────────────────
 
 /// Resolve a cached Hytale asset directory or file path.
 #[tauri::command]
@@ -122,14 +167,14 @@ pub fn resolve_bundled_hytale_asset_path(relative_path: String) -> Result<String
 /// Return the managed local Hytale asset cache root used by TerraNova.
 #[tauri::command]
 pub fn get_hytale_asset_cache_root() -> Result<String, String> {
-    crate::io::hytale_assets::ensure_hytale_assets_root()
-        .map(|path| path.to_string_lossy().to_string())
-        .map_err(|e| e.to_string())
+    let root = crate::io::hytale_assets::ensure_hytale_assets_root()
+        .map_err(|e| e.to_string())?;
+    // Register the cache as an allowed root so subsequent reads work
+    path_scope::register_allowed_root(&root);
+    Ok(root.to_string_lossy().to_string())
 }
 
 /// Sync Hytale assets into TerraNova's local cache from a release directory or Assets.zip.
-/// This command forwards a window reference so the IO layer can emit progress events
-/// (hytale-sync-start, hytale-sync-progress, hytale-sync-complete) to the caller.
 #[tauri::command]
 pub fn sync_hytale_assets(
     window: tauri::Window,
@@ -148,8 +193,7 @@ pub fn sync_hytale_assets(
 }
 
 /// Count how many files would be written by a Hytale assets sync without
-/// performing any IO. This allows the frontend to avoid starting a sync when
-/// there is nothing to do.
+/// performing any IO.
 #[tauri::command]
 pub fn count_hytale_assets_to_sync(
     source_path: String,
@@ -165,8 +209,7 @@ pub fn count_hytale_assets_to_sync(
     .map_err(|e| e.to_string())
 }
 
-/// Start a background Hytale assets sync and return immediately. Progress and
-/// completion are emitted to the caller window via events.
+/// Start a background Hytale assets sync and return immediately.
 #[tauri::command]
 pub fn start_hytale_assets_sync(
     window: tauri::Window,
@@ -198,12 +241,6 @@ pub fn cancel_hytale_assets_sync() -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
-/// Return true if the given path exists on disk (file or directory).
-#[tauri::command]
-pub fn path_exists(path: String) -> bool {
-    Path::new(&path).exists()
-}
-
 /// Check whether the Hytale asset cache is stale relative to the source path.
 #[tauri::command]
 pub fn check_hytale_asset_staleness(
@@ -211,6 +248,8 @@ pub fn check_hytale_asset_staleness(
 ) -> crate::io::hytale_assets::AssetStalenessInfo {
     crate::io::hytale_assets::check_asset_staleness(&source_path)
 }
+
+// ── Project creation commands ───────────────────────────────────────────────
 
 /// Create a blank project with the minimal HytaleGenerator folder structure.
 #[tauri::command]
@@ -227,12 +266,10 @@ pub fn create_blank_project(target_path: String) -> Result<(), String> {
 
     let gen = target.join("Server").join("HytaleGenerator");
 
-    // Create subdirectories
     for sub in &["Biomes", "Settings", "WorldStructures"] {
         fs::create_dir_all(gen.join(sub)).map_err(|e| e.to_string())?;
     }
 
-    // Settings/Settings.json
     let settings = serde_json::json!({
         "CustomConcurrency": -1,
         "BufferCapacityFactor": 0.3,
@@ -246,7 +283,6 @@ pub fn create_blank_project(target_path: String) -> Result<(), String> {
     )
     .map_err(|e| e.to_string())?;
 
-    // WorldStructures/MainWorld.json
     let world = serde_json::json!({
         "Type": "NoiseRange",
         "DefaultBiome": "DefaultBiome",
@@ -271,7 +307,6 @@ pub fn create_blank_project(target_path: String) -> Result<(), String> {
     )
     .map_err(|e| e.to_string())?;
 
-    // Biomes/DefaultBiome.json
     let biome = serde_json::json!({
         "Name": "DefaultBiome",
         "Terrain": {
@@ -292,7 +327,6 @@ pub fn create_blank_project(target_path: String) -> Result<(), String> {
     )
     .map_err(|e| e.to_string())?;
 
-    // Server/Instances/DefaultInstance/instance.bson
     let instances_dir = target.join("Server").join("Instances").join("DefaultInstance");
     fs::create_dir_all(&instances_dir).map_err(|e| e.to_string())?;
 
@@ -329,7 +363,6 @@ pub fn create_blank_project(target_path: String) -> Result<(), String> {
     )
     .map_err(|e| e.to_string())?;
 
-    // TerraNova manifest at project root (used for export metadata)
     let dir_name = target
         .file_name()
         .and_then(|n| n.to_str())
@@ -345,6 +378,9 @@ pub fn create_blank_project(target_path: String) -> Result<(), String> {
     )
     .map_err(|e| e.to_string())?;
 
+    // Register the new project as an allowed root
+    path_scope::register_allowed_root(target);
+
     Ok(())
 }
 
@@ -357,7 +393,10 @@ pub fn create_from_template(
 ) -> Result<(), String> {
     let resource_dir = app.path().resource_dir().ok();
     crate::io::template::create_from_template(&template_name, &target_path, resource_dir)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    // Register the new project as an allowed root
+    path_scope::register_allowed_root(Path::new(&target_path));
+    Ok(())
 }
 
 /// Entry representing a single biome JSON file inside a bundled template.
@@ -401,7 +440,6 @@ pub fn list_template_biomes(app: tauri::AppHandle) -> Result<Vec<TemplateBiomeEn
                 .join(" ")
         };
 
-        // Walk subdirectories looking for Biomes/**/*.json
         collect_biome_files(
             &template_entry.path(),
             &template_name,
@@ -443,7 +481,6 @@ fn collect_biome_files_inner(
     let Ok(read_dir) = fs::read_dir(dir) else { return };
     for entry in read_dir.flatten() {
         let path = entry.path();
-        // Skip symlinks to prevent cycles
         if path.is_symlink() {
             continue;
         }
@@ -473,20 +510,15 @@ fn collect_biome_files_inner(
     }
 }
 
+// ── Explorer / filesystem utility commands ───────────────────────────────────
+
 /// Reveal a file or folder in the OS file explorer.
-/// On Windows: opens Explorer with the item selected.
-/// On macOS:   opens Finder with the item selected via `open -R`.
-/// On Linux:   opens the parent directory with xdg-open.
 #[tauri::command]
 pub fn show_in_folder(path: String) -> Result<(), String> {
     let target = PathBuf::from(&path);
 
     #[cfg(target_os = "windows")]
     {
-        // explorer.exe requires the path to use backslashes and be passed as
-        // two separate arguments: "/select," and then the path itself.
-        // Passing them concatenated as one arg causes Explorer to ignore the
-        // /select flag and just open the folder root.
         let path_str = target.to_string_lossy().replace('/', "\\");
         if target.is_file() {
             Command::new("explorer")

--- a/src-tauri/src/io/mod.rs
+++ b/src-tauri/src/io/mod.rs
@@ -1,3 +1,4 @@
 pub mod asset_pack;
 pub mod hytale_assets;
+pub mod path_scope;
 pub mod template;

--- a/src-tauri/src/io/path_scope.rs
+++ b/src-tauri/src/io/path_scope.rs
@@ -1,0 +1,92 @@
+//! Path scope validation for filesystem commands.
+//!
+//! All filesystem commands that accept user-supplied paths should validate them
+//! against registered allowed roots before performing any I/O. This prevents a
+//! compromised webview from reading/writing arbitrary filesystem locations.
+
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+/// Global set of allowed root directories. Paths passed to filesystem commands
+/// must fall under one of these roots (after canonicalization).
+static ALLOWED_ROOTS: RwLock<Vec<PathBuf>> = RwLock::new(Vec::new());
+
+/// Register an allowed root directory. Called when the user opens a project or
+/// when the hytale-assets cache is initialised.
+pub fn register_allowed_root(root: &Path) {
+    if let Ok(canonical) = std::fs::canonicalize(root) {
+        let mut roots = ALLOWED_ROOTS.write().unwrap_or_else(|e| e.into_inner());
+        if !roots.iter().any(|r| r == &canonical) {
+            roots.push(canonical);
+        }
+    }
+}
+
+/// Remove a previously registered root (e.g. when a project is closed).
+pub fn unregister_allowed_root(root: &Path) {
+    if let Ok(canonical) = std::fs::canonicalize(root) {
+        let mut roots = ALLOWED_ROOTS.write().unwrap_or_else(|e| e.into_inner());
+        roots.retain(|r| r != &canonical);
+    }
+}
+
+/// Validate that `path` falls under at least one registered allowed root.
+///
+/// For files that don't exist yet (writes/creates), we canonicalize the nearest
+/// existing ancestor and check that.
+pub fn validate_path(path: &str) -> Result<PathBuf, String> {
+    let target = PathBuf::from(path);
+
+    // Try to canonicalize the path directly (works if it exists)
+    let canonical = if target.exists() {
+        target.canonicalize().map_err(|e| format!("Invalid path: {}", e))?
+    } else {
+        // For new files: canonicalize the nearest existing ancestor
+        let mut ancestor = target.clone();
+        loop {
+            if let Some(parent) = ancestor.parent() {
+                if parent.exists() {
+                    let canon_parent = parent
+                        .canonicalize()
+                        .map_err(|e| format!("Invalid path: {}", e))?;
+                    // Re-append the remaining segments
+                    let suffix = target
+                        .strip_prefix(parent)
+                        .unwrap_or(target.file_name().map(Path::new).unwrap_or(Path::new("")));
+                    break canon_parent.join(suffix);
+                }
+                ancestor = parent.to_path_buf();
+            } else {
+                return Err("Path has no valid ancestor directory".into());
+            }
+        }
+    };
+
+    let roots = ALLOWED_ROOTS.read().unwrap_or_else(|e| e.into_inner());
+
+    // If no roots are registered yet, allow everything (backward compat during
+    // startup before a project is opened). This is a deliberate tradeoff:
+    // commands like show_in_folder and path_exists may be called before any
+    // project is open.
+    if roots.is_empty() {
+        return Ok(canonical);
+    }
+
+    for root in roots.iter() {
+        if canonical.starts_with(root) {
+            return Ok(canonical);
+        }
+    }
+
+    Err(format!(
+        "Path is outside allowed project scope: {}",
+        target.display()
+    ))
+}
+
+/// Convenience: validate and return the original string (for commands that
+/// pass strings through to std::fs).
+pub fn validate_path_str(path: &str) -> Result<String, String> {
+    validate_path(path)?;
+    Ok(path.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,8 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .manage(BridgeState::default())
         .invoke_handler(tauri::generate_handler![
+            io_commands::register_project_root,
+            io_commands::unregister_project_root,
             io_commands::open_asset_pack,
             io_commands::save_asset_pack,
             io_commands::read_asset_file,

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { emit, on } from "./storeEvents";
+import { registerProjectRoot, unregisterProjectRoot } from "@/utils/ipc";
 
 export interface DirectoryEntry {
   name: string;
@@ -41,7 +42,12 @@ export const useProjectStore = create<ProjectState>((set) => ({
   isDirty: false,
   lastError: null,
 
-  setProjectPath: (path) => set({ projectPath: path }),
+  setProjectPath: (path) => {
+    const prev = useProjectStore.getState().projectPath;
+    if (prev) unregisterProjectRoot(prev).catch(() => {});
+    if (path) registerProjectRoot(path).catch(() => {});
+    set({ projectPath: path });
+  },
   setAssetFiles: (files) => set({ assetFiles: files }),
   setDirectoryTree: (tree) => set({ directoryTree: tree }),
   setCurrentFile: (file) => set({ currentFile: file }),
@@ -57,6 +63,8 @@ export const useProjectStore = create<ProjectState>((set) => ({
       lastError: null,
     }),
   closeProject: () => {
+    const prev = useProjectStore.getState().projectPath;
+    if (prev) unregisterProjectRoot(prev).catch(() => {});
     set({
       projectPath: null,
       assetFiles: [],

--- a/src/utils/ipc.ts
+++ b/src/utils/ipc.ts
@@ -40,6 +40,14 @@ export interface ValidationError {
   severity: "Error" | "Warning" | "Info";
 }
 
+export async function registerProjectRoot(path: string): Promise<void> {
+  return invoke("register_project_root", { path });
+}
+
+export async function unregisterProjectRoot(path: string): Promise<void> {
+  return invoke("unregister_project_root", { path });
+}
+
 export async function openAssetPack(path: string): Promise<AssetPackData> {
   return invoke<AssetPackData>("open_asset_pack", { path });
 }


### PR DESCRIPTION
## Summary

- Add `path_scope` module that maintains a set of allowed root directories
- All filesystem commands (`read_asset_file`, `write_asset_file`, `export_asset_file`, `write_text_file`, `copy_file`, `create_directory`, `list_directory`, `open_asset_pack`, `save_asset_pack`) now validate paths against registered roots before performing I/O
- Roots registered automatically when projects are opened/created and when the hytale-assets cache is initialized
- `path_exists` left unscoped (read-only, needed pre-project for settings)
- When no roots are registered (startup), all paths allowed for backward compat

## Motivation

The Tauri commands in `io.rs` use `std::fs` directly, bypassing `tauri-plugin-fs` scoping. A compromised webview (XSS, supply chain attack) could read/write anywhere on the filesystem. This adds defense-in-depth by validating all paths against registered project roots.

## Files changed

- **New:** `src-tauri/src/io/path_scope.rs` — scope validation module
- **Modified:** `src-tauri/src/io/mod.rs` — register new module
- **Modified:** `src-tauri/src/commands/io.rs` — add validation to all commands, add `register_project_root`/`unregister_project_root` commands
- **Modified:** `src-tauri/src/lib.rs` — register new commands
- **Modified:** `src/utils/ipc.ts` — add IPC wrappers for scope registration
- **Modified:** `src/stores/projectStore.ts` — auto-register/unregister on project open/close

## Test plan

- [x] Open a project — filesystem operations work normally
- [x] Close and reopen a different project — operations scoped to new project
- [x] Hytale asset cache operations work after sync
- [x] App startup before opening a project — settings dialog and other pre-project operations work
- [x] Verify that paths outside the project root are rejected (manual test via dev console)