### PR TITLE
feat: restore session state on page reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import type { SvgExportOptions } from "@/utils/exportSvg";
 import { useReactFlow } from "@xyflow/react";
 import { useGlobalKeyboardShortcuts } from "@/hooks/useGlobalKeyboardShortcuts";
 import { useInstantSave } from "@/hooks/useInstantSave";
+import { useSessionRestore } from "@/hooks/useSessionRestore";
 
 type PendingAction = "window-close" | "close-project";
 
@@ -138,6 +139,9 @@ export default function App() {
       if (unlistenFn) unlistenFn();
     };
   }, []);
+
+  // Restore previous session (project path) on app mount
+  useSessionRestore();
 
   const projectPath = useProjectStore((s) => s.projectPath);
 

--- a/src/components/layout/PanelLayout.tsx
+++ b/src/components/layout/PanelLayout.tsx
@@ -10,6 +10,8 @@ import { HistoryPanel } from "@/components/editor/HistoryPanel";
 import { ValidationPanel } from "@/components/editor/ValidationPanel";
 import { Toolbar } from "@/components/layout/Toolbar";
 import { useGraphDiagnostics } from "@/hooks/useGraphDiagnostics";
+import { useSessionRestoreFile } from "@/hooks/useSessionRestore";
+import { useTauriIO } from "@/hooks/useTauriIO";
 import { useUIStore, type SidebarSectionId } from "@/stores/uiStore";
 import { useEditorStore } from "@/stores/editorStore";
 import { useProjectStore } from "@/stores/projectStore";
@@ -288,6 +290,10 @@ export function PanelLayout() {
 
   // Drive diagnostics computation (debounced, pushes to diagnosticsStore)
   useGraphDiagnostics();
+
+  // Restore previously open file after session reload (Phase 2)
+  const { openFile } = useTauriIO();
+  useSessionRestoreFile(openFile);
 
   // Persist widths to localStorage when they change
   useEffect(() => {

--- a/src/hooks/useSessionRestore.ts
+++ b/src/hooks/useSessionRestore.ts
@@ -1,0 +1,96 @@
+/**
+ * Restore navigation session on app mount.
+ *
+ * Phase 1 (useSessionRestore): Restores projectPath so ProjectEditor renders.
+ * Phase 2 (useSessionRestoreFile): Once inside ReactFlowProvider, opens the
+ * previously active file and biome section.
+ */
+
+import { useEffect, useRef } from "react";
+import { loadSession, clearSession } from "@/utils/sessionPersist";
+import { useProjectStore } from "@/stores/projectStore";
+import { useRecentProjectsStore } from "@/stores/recentProjectsStore";
+import { useEditorStore } from "@/stores/editorStore";
+import { listDirectory } from "@/utils/ipc";
+import mapDirEntry from "@/utils/mapDirEntry";
+
+/**
+ * Phase 1: Call in App component. Restores projectPath + directory tree
+ * so the editor mounts instead of the home screen.
+ */
+export function useSessionRestore(): void {
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    // Only attempt restore when starting fresh (no project already loaded)
+    if (useProjectStore.getState().projectPath !== null) return;
+
+    const session = loadSession();
+    if (!session.projectPath) return;
+
+    (async () => {
+      try {
+        useProjectStore.getState().setProjectPath(session.projectPath);
+        const entries = await listDirectory(session.projectPath!);
+        useProjectStore.getState().setDirectoryTree(entries.map(mapDirEntry));
+        useRecentProjectsStore.getState().addProject(session.projectPath!);
+      } catch {
+        // Project path no longer valid — clear and stay on home screen
+        clearSession();
+        useProjectStore.getState().reset();
+      }
+    })();
+  }, []);
+}
+
+/**
+ * Phase 2: Call inside ProjectEditor (within ReactFlowProvider).
+ * Opens the previously active file using the provided openFile callback.
+ *
+ * Uses a ref for the callback so we always invoke the latest version,
+ * and waits for the directory tree to be populated (indicating Phase 1 finished).
+ */
+export function useSessionRestoreFile(
+  openFile: (filePath: string) => Promise<void>,
+): void {
+  const openFileRef = useRef(openFile);
+  openFileRef.current = openFile;
+
+  const ranRef = useRef(false);
+
+  // Watch for directory tree to become available (Phase 1 completion signal)
+  const directoryTree = useProjectStore((s) => s.directoryTree);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    // Wait until Phase 1 has populated the directory tree
+    if (directoryTree.length === 0) return;
+
+    ranRef.current = true;
+
+    const session = loadSession();
+    if (!session.currentFile) return;
+
+    // Use a brief delay to ensure React has flushed all store updates
+    const timer = setTimeout(async () => {
+      try {
+        await openFileRef.current(session.currentFile!);
+
+        // Restore biome section if applicable
+        if (session.activeBiomeSection) {
+          const { biomeSections, switchBiomeSection } = useEditorStore.getState();
+          if (biomeSections && session.activeBiomeSection in biomeSections) {
+            switchBiomeSection(session.activeBiomeSection);
+          }
+        }
+      } catch {
+        // File no longer exists — user can manually pick a new one
+      }
+    }, 50);
+
+    return () => clearTimeout(timer);
+  }, [directoryTree]);
+}

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { emit, on } from "./storeEvents";
 import { registerProjectRoot, unregisterProjectRoot } from "@/utils/ipc";
+import { saveSession, clearSession } from "@/utils/sessionPersist";
 
 export interface DirectoryEntry {
   name: string;
@@ -47,13 +48,17 @@ export const useProjectStore = create<ProjectState>((set) => ({
     if (prev) unregisterProjectRoot(prev).catch(() => {});
     if (path) registerProjectRoot(path).catch(() => {});
     set({ projectPath: path });
+    saveSession({ projectPath: path });
   },
   setAssetFiles: (files) => set({ assetFiles: files }),
   setDirectoryTree: (tree) => set({ directoryTree: tree }),
-  setCurrentFile: (file) => set({ currentFile: file }),
+  setCurrentFile: (file) => {
+    set({ currentFile: file });
+    saveSession({ currentFile: file });
+  },
   setDirty: (dirty) => set({ isDirty: dirty }),
   setLastError: (error) => set({ lastError: error }),
-  reset: () =>
+  reset: () => {
     set({
       projectPath: null,
       assetFiles: [],
@@ -61,7 +66,9 @@ export const useProjectStore = create<ProjectState>((set) => ({
       currentFile: null,
       isDirty: false,
       lastError: null,
-    }),
+    });
+    clearSession();
+  },
   closeProject: () => {
     const prev = useProjectStore.getState().projectPath;
     if (prev) unregisterProjectRoot(prev).catch(() => {});
@@ -73,6 +80,7 @@ export const useProjectStore = create<ProjectState>((set) => ({
       isDirty: false,
       lastError: null,
     });
+    clearSession();
     emit("project:close");
   },
 }));

--- a/src/stores/slices/biomeSectionsSlice.ts
+++ b/src/stores/slices/biomeSectionsSlice.ts
@@ -1,5 +1,6 @@
 import { useUIStore } from "../uiStore";
 import { emit } from "../storeEvents";
+import { saveSession } from "@/utils/sessionPersist";
 import type {
   EditorState,
   SliceCreator,
@@ -31,7 +32,10 @@ export const createBiomeSectionsSlice: SliceCreator<BiomeSectionsSliceState> = (
     ...biomeSectionsInitialState,
 
     setBiomeSections: (sections) => set({ biomeSections: sections }),
-    setActiveBiomeSection: (section) => set({ activeBiomeSection: section }),
+    setActiveBiomeSection: (section) => {
+      set({ activeBiomeSection: section });
+      saveSession({ activeBiomeSection: section });
+    },
     setBiomeConfig: (config) => set({ biomeConfig: config }),
 
     switchBiomeSection: (target) => {
@@ -61,6 +65,7 @@ export const createBiomeSectionsSlice: SliceCreator<BiomeSectionsSliceState> = (
           outputNodeId: targetData.outputNodeId ?? null,
           selectedNodeId: null,
         });
+        saveSession({ activeBiomeSection: target });
         // Reload per-tab bookmarks for the new section
         useUIStore.getState().reloadBookmarks(undefined, undefined, target);
       }

--- a/src/utils/sessionPersist.ts
+++ b/src/utils/sessionPersist.ts
@@ -1,0 +1,42 @@
+/**
+ * Persist and restore navigation session state across page reloads.
+ *
+ * Saves projectPath, currentFile, and activeBiomeSection to localStorage
+ * so the app can resume where the user left off after a reload.
+ */
+
+const SESSION_KEY = "tn-session";
+
+export interface SessionState {
+  projectPath: string | null;
+  currentFile: string | null;
+  activeBiomeSection: string | null;
+}
+
+export function saveSession(state: Partial<SessionState>): void {
+  try {
+    const current = loadSession();
+    const merged = { ...current, ...state };
+    localStorage.setItem(SESSION_KEY, JSON.stringify(merged));
+  } catch {
+    // localStorage may be unavailable in some contexts
+  }
+}
+
+export function loadSession(): SessionState {
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) return { projectPath: null, currentFile: null, activeBiomeSection: null };
+    return JSON.parse(raw) as SessionState;
+  } catch {
+    return { projectPath: null, currentFile: null, activeBiomeSection: null };
+  }
+}
+
+export function clearSession(): void {
+  try {
+    localStorage.removeItem(SESSION_KEY);
+  } catch {
+    // noop
+  }
+}


### PR DESCRIPTION
## Summary

- Persist `projectPath`, `currentFile`, and `activeBiomeSection` to localStorage on navigation changes
- On reload, restore the project directory tree (Phase 1), then reopen the active file and biome section (Phase 2)
- Clear session state when the user explicitly closes the project

Previously, reloading the app always returned to the home screen, losing all navigation context. Now the user returns to exactly where they were — same project, same file, same biome tab.

## Test plan

- [x] All 994 tests pass (1 pre-existing env path failure on main)
- [x] Manual: open project → open biome → switch to Props tab → reload → returns to Props tab
- [x] Manual: close project → reload → stays on home screen (session cleared)
- [x] Manual: open project with deleted path → reload → falls back to home screen gracefully