### PR TITLE
fix: work around EGL init failure on Linux Intel GPUs

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,12 +13,22 @@ pub static NvOptimusEnablement: u32 = 0x00000001;
 pub static AmdPowerXpressRequestHighPerformance: u32 = 0x00000001;
 
 fn main() {
-    // Work around WebKitGTK protocol error on Wayland with NVIDIA proprietary
-    // drivers (GH-9). The DMA-BUF renderer triggers "Error 71 (Protocol error)
-    // dispatching to Wayland display" and an instant crash on affected systems.
+    // Work around WebKitGTK rendering issues on Linux (GH-9, GH-36).
+    //
+    // WEBKIT_DISABLE_DMABUF_RENDERER  – prevents "Error 71 (Protocol error)
+    //   dispatching to Wayland display" crash with NVIDIA proprietary drivers.
+    //
+    // WEBKIT_DISABLE_COMPOSITING_MODE – prevents "Could not create default EGL
+    //   display: EGL_BAD_PARAMETER" on Intel integrated GPUs (e.g. Iris Xe)
+    //   where EGL initialization fails outright, producing a blank window.
     #[cfg(target_os = "linux")]
-    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    {
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+        if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
+            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        }
     }
 
     terranova_lib::run()


### PR DESCRIPTION
Closes #36

## Summary
- Adds `WEBKIT_DISABLE_COMPOSITING_MODE=1` env var at startup on Linux to prevent WebKitGTK from attempting EGL-based GPU compositing
- This fixes blank window / crash on Intel integrated GPUs (e.g. Iris Xe) where EGL initialization fails with `EGL_BAD_PARAMETER`
- Existing `WEBKIT_DISABLE_DMABUF_RENDERER` workaround for NVIDIA preserved alongside

## Test plan
- [ ] Verify on Linux with Intel Iris Xe (or similar iGPU) that the app renders instead of showing a blank window
- [ ] Verify on Linux with NVIDIA that the existing DMA-BUF workaround still functions
- [ ] Verify on Windows/macOS that behavior is unchanged (env vars are `#[cfg(target_os = "linux")]` gated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux startup compatibility with enhanced WebKitGTK environment variable configuration to address known display rendering and performance issues on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->