### PR TITLE
fix: pin linuxdeploy and refine WebKitGTK workarounds for Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,14 @@ jobs:
           "
         shell: bash
 
+      - name: Pin linuxdeploy to fix AppImage EGL rendering
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          TAURI_TOOLS="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+          mkdir -p "$TAURI_TOOLS"
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage -O "$TAURI_TOOLS/linuxdeploy-x86_64.AppImage"
+          chmod +x "$TAURI_TOOLS/linuxdeploy-x86_64.AppImage"
+
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,20 +14,27 @@ pub static AmdPowerXpressRequestHighPerformance: u32 = 0x00000001;
 
 fn main() {
     // Work around WebKitGTK rendering issues on Linux (GH-9, GH-36).
+    // See also: https://github.com/kanriapp/kanri/issues/805
     //
-    // WEBKIT_DISABLE_DMABUF_RENDERER  – prevents "Error 71 (Protocol error)
+    // WEBKIT_DISABLE_COMPOSITING_MODE - prevents "Could not create default
+    //   EGL display: EGL_BAD_PARAMETER" on Intel iGPUs and other systems
+    //   where EGL initialization fails, producing a blank window.
+    //   Set unconditionally (Wayland and X11 both affected).
+    //
+    // WEBKIT_DISABLE_DMABUF_RENDERER - prevents "Error 71 (Protocol error)
     //   dispatching to Wayland display" crash with NVIDIA proprietary drivers.
-    //
-    // WEBKIT_DISABLE_COMPOSITING_MODE – prevents "Could not create default EGL
-    //   display: EGL_BAD_PARAMETER" on Intel integrated GPUs (e.g. Iris Xe)
-    //   where EGL initialization fails outright, producing a blank window.
+    //   Only needed on X11 with DRI present; Wayland handles DMA-BUF natively.
     #[cfg(target_os = "linux")]
     {
-        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
-            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-        }
         if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
             std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        }
+        if std::path::Path::new("/dev/dri").exists()
+            && std::env::var("WAYLAND_DISPLAY").is_err()
+        {
+            if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+            }
         }
     }
 


### PR DESCRIPTION
Closes #36

## Summary
- Pin linuxdeploy to `1-alpha-20250213-2` in the release workflow to fix AppImage EGL/Mesa library bundling (root cause of blank window)
- Refine runtime env var workarounds based on findings from kanriapp/kanri#805:
  - Always set `WEBKIT_DISABLE_COMPOSITING_MODE` (X11 and Wayland both affected)
  - Only set `WEBKIT_DISABLE_DMABUF_RENDERER` on X11 with DRI present

## Context
Tauri's bundled linuxdeploy is outdated and strips/mispackages EGL libraries in AppImages. The env vars alone were insufficient for many users. Pinning a newer linuxdeploy is the fix confirmed working by multiple Tauri apps (Kanri, Jan, GitButler).

## Test plan
- [ ] Build AppImage via release workflow and verify it renders on Intel iGPUs (Iris Xe, etc.)
- [ ] Verify .deb and .rpm packages still work
- [ ] Verify Windows/macOS builds unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux startup by refining WebKitGTK environment variable configuration for X11 and Wayland sessions.

* **Chores**
  * Enhanced CI/CD pipeline with cached binary dependencies for faster Ubuntu builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->