### PR TITLE
fix: correct tauri signer CLI arguments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,8 +171,9 @@ jobs:
           # The signer reads TAURI_SIGNING_PRIVATE_KEY from the environment.
           if [ -n "$TAURI_SIGNING_PRIVATE_KEY" ]; then
             pnpm tauri signer sign \
+              --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
               --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
-              --file "$APPIMAGE"
+              "$APPIMAGE"
             echo "Re-signed: ${APPIMAGE}.sig"
           fi
 


### PR DESCRIPTION
Follow-up to #43

The Tauri v2 signer takes the file as a positional argument (not `--file`) and requires `--private-key` explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline configuration to properly handle AppImage signing during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->